### PR TITLE
Fixing 5m SAS - Docking Port Sr model file was renamed in 1.12

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_SAS_500.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_SAS_500.cfg
@@ -14,14 +14,14 @@ MODEL
 }
 MODEL
 {
-	model = Squad/Parts/Utility/dockingPortSr/model
+	model = Squad/Parts/Utility/dockingPortSr/dockingPortSr
 	position = 0,-.6,0
 	scale = 2,3,2
 	rotation = 180,0,0
 }
 MODEL
 {
-	model = Squad/Parts/Utility/dockingPortSr/model
+	model = Squad/Parts/Utility/dockingPortSr/dockingPortSr
 	position = 0,.6,0
 	scale = 2,3,2
 }


### PR DESCRIPTION
This part uses the Docking Port Sr model, and this was renamed in 1.12.